### PR TITLE
Conditionally load header bar

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,7 +10,7 @@ import pLimit from "p-limit";
 import "./css/style.css";
 import "materialize-css/dist/css/materialize.min.css";
 import "choices.js/public/assets/styles/choices.min.css";
-
+import { loadLegacyHeaderBarIfNeeded } from "./js/check-header-bar.js";
 
 
 let validationResultsFilter, unusedVariablesFilter;
@@ -26,6 +26,7 @@ function extractVariables(str) {
 }
 
 document.addEventListener("DOMContentLoaded", async function () {
+    loadLegacyHeaderBarIfNeeded();
     const programs = await d2Get("api/programs.json?fields=name,id&paging=false");
     const programChoices = new Choices("#programDropdown", {
         choices: programs.programs.map(program => ({ value: program.id, label: program.name })),

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,6 @@
 <head>
     <meta charset="utf-8" name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <script defer src="resources/dhis-header-bar.js"></script>
 </head>
 
 <body>

--- a/src/js/check-header-bar.js
+++ b/src/js/check-header-bar.js
@@ -16,7 +16,7 @@ function parseServerVersion(versionString) {
 
 async function shouldLoadLegacyHeaderBar() {
     try {
-        const response = await d2Get("system/info.json?fields=version");
+        const response = await d2Get("api/system/info.json?fields=version");
         const versionInfo = parseServerVersion(response.version || "0.0.0");
         return versionInfo.minor < 42;
     } catch (error) {

--- a/src/js/check-header-bar.js
+++ b/src/js/check-header-bar.js
@@ -1,0 +1,39 @@
+import { d2Get } from "./d2api.js";
+
+
+function parseServerVersion(versionString) {
+    const snapshot = versionString.includes("SNAPSHOT");
+    const cleanedVersion = versionString.replace("-SNAPSHOT", "");
+    const [majorStr, minorStr, patchStr = "0"] = cleanedVersion.split(".");
+    
+    return {
+        major: parseInt(majorStr, 10),
+        minor: parseInt(minorStr, 10),
+        patch: parseInt(patchStr, 10),
+        snapshot
+    };
+}
+
+async function shouldLoadLegacyHeaderBar() {
+    try {
+        const response = await d2Get("system/info.json?fields=version");
+        const versionInfo = parseServerVersion(response.version || "0.0.0");
+        return versionInfo.minor < 43;
+    } catch (error) {
+        console.error("Error fetching server version:", error);
+        return true;
+    }
+}
+
+export async function loadLegacyHeaderBarIfNeeded() {
+    const shouldLoad = await shouldLoadLegacyHeaderBar();
+    if (shouldLoad) {
+        const script = document.createElement("script");
+        script.src = "resources/dhis-header-bar.js";
+        script.defer = true;
+        document.head.appendChild(script);
+    } else {
+        const headerBar = document.getElementById("dhis-header-bar");
+        if (headerBar) headerBar.style.display = "none";
+    }
+}

--- a/src/js/check-header-bar.js
+++ b/src/js/check-header-bar.js
@@ -18,7 +18,7 @@ async function shouldLoadLegacyHeaderBar() {
     try {
         const response = await d2Get("system/info.json?fields=version");
         const versionInfo = parseServerVersion(response.version || "0.0.0");
-        return versionInfo.minor < 43;
+        return versionInfo.minor < 42;
     } catch (error) {
         console.error("Error fetching server version:", error);
         return true;


### PR DESCRIPTION
To changes in this PR: 
1) Do not load the legacy header bar if we are on a  server with minor version >= 42.
2) Some PRVs were being incorrectly flagged as not being used due to peculiarities of the DHIS2 expression syntax. Adjustments were made to the code which handles the indentification of PRV to make it more robust. 